### PR TITLE
feat: 로그인/회원가입 API 연동 및 Jotai 기반 유저 상태 관리 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/vite": "^4.1.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jotai": "^2.13.1",
         "lightweight-charts": "^5.0.8",
         "lucide-react": "^0.540.0",
         "react": "^19.1.0",
@@ -46,7 +47,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -60,7 +61,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -75,7 +76,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
       "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -85,7 +86,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -116,7 +117,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
       "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -133,7 +134,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -150,7 +151,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -160,7 +161,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -174,7 +175,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -202,7 +203,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -212,7 +213,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -222,7 +223,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -232,7 +233,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
       "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -246,7 +247,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
       "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -294,7 +295,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -309,7 +310,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
       "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -328,7 +329,7 @@
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
       "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2531,7 +2532,7 @@
       "version": "4.25.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
       "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2587,7 +2588,7 @@
       "version": "1.0.30001737",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
       "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2692,7 +2693,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2767,7 +2768,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2812,7 +2813,7 @@
       "version": "1.5.208",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.208.tgz",
       "integrity": "sha512-ozZyibehoe7tOhNaf16lKmljVf+3npZcJIEbJRVftVsmAg5TeA1mGS9dVCZzOwr2xT7xK15V0p7+GZqSPgkuPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2896,7 +2897,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3286,7 +3287,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3448,11 +3449,40 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.13.1.tgz",
+      "integrity": "sha512-cRsw6kFeGC9Z/D3egVKrTXRweycZ4z/k7i2MrfCzPYsL9SIWcPXTyqv258/+Ay8VUEcihNiE/coBLE6Kic6b8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3472,7 +3502,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -3513,7 +3543,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3827,7 +3857,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3928,7 +3958,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4011,7 +4041,7 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/npm-normalize-package-bin": {
@@ -4494,7 +4524,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4825,7 +4855,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5071,7 +5101,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@supabase/supabase-js": "^2.56.0",
         "@tailwindcss/vite": "^4.1.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1450,6 +1451,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
+      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
+      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.56.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.56.0.tgz",
+      "integrity": "sha512-XqwhHSyVnkjdliPN61CmXsmFGnFHTX2WDdwjG3Ukvdzuu3Trix+dXupYOQ3BueIyYp7B6t0yYpdQtJP2hIInyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.3",
+        "@supabase/realtime-js": "2.15.1",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -1999,11 +2074,16 @@
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.11",
@@ -2023,6 +2103,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4639,6 +4728,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4724,7 +4819,6 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4896,6 +4990,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4934,6 +5044,27 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@supabase/supabase-js": "^2.56.0",
     "@tailwindcss/vite": "^4.1.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.1.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jotai": "^2.13.1",
     "lightweight-charts": "^5.0.8",
     "lucide-react": "^0.540.0",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,10 @@ import MainLayout from "@/layouts/MainLayout";
 
 function App() {
   return (
-      <MainLayout>
-          <div></div>
-      </MainLayout>
-  )
+    <MainLayout>
+      <div></div>
+    </MainLayout>
+  );
 }
 
-export default App
+export default App;

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -4,12 +4,18 @@ import type { FC, ReactNode } from "react";
 type AuthCardProps = {
   children: ReactNode;
   footer?: ReactNode;
+  errorMessage?: string;
 };
 
-const AuthCard: FC<AuthCardProps> = ({ children, footer }) => {
+const AuthCard: FC<AuthCardProps> = ({ children, footer, errorMessage }) => {
   return (
-    <Card className="w-[404px]">
-      <CardContent>{children}</CardContent>
+    <Card className="w-[404px] gap-4">
+      <CardContent>
+        {children}
+        {errorMessage && (
+          <p className="text-xs text-red-500 pt-1">{errorMessage}</p>
+        )}
+      </CardContent>
       {footer && <CardFooter>{footer}</CardFooter>}
     </Card>
   );

--- a/src/components/auth/EmailCodeStep.tsx
+++ b/src/components/auth/EmailCodeStep.tsx
@@ -1,26 +1,25 @@
 import AuthCard from "@/components/auth/AuthCard.tsx";
 import { Input } from "@/components/ui/input.tsx";
-import { type FC, useState } from "react";
+import { type FC } from "react";
 import { Button } from "@/components/ui/button.tsx";
 
 type EmailCodeStepProps = {
-  onChangeStep: () => void;
+  email: string;
+  verifyCode: string;
+  isCodeSent: boolean;
+  onChangeEmail: (v: string) => void; // ✅ 변경 콜백
+  onChangeVerifyCode: (v: string) => void;
+  handleVerificationAction: () => void;
 };
 
-const EmailCodeStep: FC<EmailCodeStepProps> = ({ onChangeStep }) => {
-  const [isCodeSent, setIsCodeSent] = useState(false);
-  const [email, setEmail] = useState("");
-  const [verifyCode, setVerifyCode] = useState("");
-  const handleVerificationAction = () => {
-    if (!isCodeSent) {
-      // TODO: 이메일로 인증코드 발송 API
-      setIsCodeSent(true);
-    } else {
-      // TODO: 인증번호 검증 API
-      onChangeStep();
-    }
-  };
-
+const EmailCodeStep: FC<EmailCodeStepProps> = ({
+  email,
+  verifyCode,
+  onChangeEmail,
+  onChangeVerifyCode,
+  isCodeSent,
+  handleVerificationAction,
+}) => {
   const footer = (
     <Button
       className="w-full h-10"
@@ -41,7 +40,7 @@ const EmailCodeStep: FC<EmailCodeStepProps> = ({ onChangeStep }) => {
             placeholder="이메일"
             autoComplete="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => onChangeEmail(e.target.value)}
             required
           />
           {isCodeSent && (
@@ -51,7 +50,7 @@ const EmailCodeStep: FC<EmailCodeStepProps> = ({ onChangeStep }) => {
               autoComplete="one-time-code"
               placeholder="인증번호"
               value={verifyCode}
-              onChange={(e) => setVerifyCode(e.target.value)}
+              onChange={(e) => onChangeVerifyCode(e.target.value)}
             />
           )}
         </div>

--- a/src/components/auth/EmailCodeStep.tsx
+++ b/src/components/auth/EmailCodeStep.tsx
@@ -7,7 +7,7 @@ type EmailCodeStepProps = {
   email: string;
   verifyCode: string;
   isCodeSent: boolean;
-  onChangeEmail: (v: string) => void; // ✅ 변경 콜백
+  onChangeEmail: (v: string) => void;
   onChangeVerifyCode: (v: string) => void;
   handleVerificationAction: () => void;
 };
@@ -15,9 +15,9 @@ type EmailCodeStepProps = {
 const EmailCodeStep: FC<EmailCodeStepProps> = ({
   email,
   verifyCode,
+  isCodeSent,
   onChangeEmail,
   onChangeVerifyCode,
-  isCodeSent,
   handleVerificationAction,
 }) => {
   const footer = (

--- a/src/components/auth/EmailCodeStep.tsx
+++ b/src/components/auth/EmailCodeStep.tsx
@@ -10,6 +10,7 @@ type EmailCodeStepProps = {
   onChangeEmail: (v: string) => void;
   onChangeVerifyCode: (v: string) => void;
   handleVerificationAction: () => void;
+  errorMessage: string;
 };
 
 const EmailCodeStep: FC<EmailCodeStepProps> = ({
@@ -19,6 +20,7 @@ const EmailCodeStep: FC<EmailCodeStepProps> = ({
   onChangeEmail,
   onChangeVerifyCode,
   handleVerificationAction,
+  errorMessage,
 }) => {
   const footer = (
     <Button
@@ -31,7 +33,7 @@ const EmailCodeStep: FC<EmailCodeStepProps> = ({
   );
 
   return (
-    <AuthCard footer={footer}>
+    <AuthCard footer={footer} errorMessage={errorMessage}>
       <form>
         <div className="flex flex-col gap-2">
           <Input
@@ -49,6 +51,7 @@ const EmailCodeStep: FC<EmailCodeStepProps> = ({
               type="text"
               autoComplete="one-time-code"
               placeholder="인증번호"
+              maxLength={6}
               value={verifyCode}
               onChange={(e) => onChangeVerifyCode(e.target.value)}
             />

--- a/src/components/auth/PasswordStep.tsx
+++ b/src/components/auth/PasswordStep.tsx
@@ -22,6 +22,13 @@ const PasswordStep: FC<PasswordStepProps> = ({
   const isMatch = password === passwordConfirm && passwordConfirm.length > 0;
   const canSubmit = isLengthOk && isMatch;
 
+  const errorMessage =
+    password.length > 0 && !isLengthOk
+      ? "비밀번호는 최소 8자 이상이어야 합니다."
+      : passwordConfirm.length > 0 && !isMatch
+        ? "비밀번호가 일치하지 않습니다."
+        : "";
+
   const footer = (
     <Button
       className="w-full h-10"
@@ -33,7 +40,7 @@ const PasswordStep: FC<PasswordStepProps> = ({
   );
 
   return (
-    <AuthCard footer={footer}>
+    <AuthCard footer={footer} errorMessage={errorMessage}>
       <form>
         <div className="flex flex-col gap-2">
           <Input
@@ -54,16 +61,6 @@ const PasswordStep: FC<PasswordStepProps> = ({
             value={passwordConfirm}
             onChange={(e) => onChangePasswordConfirm(e.target.value)}
           />
-          {!isLengthOk && password.length > 0 && (
-            <p className="text-xs text-red-500">
-              비밀번호는 최소 8자 이상이어야 합니다.
-            </p>
-          )}
-          {!isMatch && passwordConfirm.length > 0 && (
-            <p className="text-xs text-red-500">
-              비밀번호가 일치하지 않습니다.
-            </p>
-          )}
         </div>
       </form>
     </AuthCard>

--- a/src/components/auth/PasswordStep.tsx
+++ b/src/components/auth/PasswordStep.tsx
@@ -1,25 +1,32 @@
 import AuthCard from "@/components/auth/AuthCard.tsx";
 import { Input } from "@/components/ui/input.tsx";
-import { type FC, useState } from "react";
+import { type FC } from "react";
 import { Button } from "@/components/ui/button.tsx";
 
-const PasswordStep: FC = () => {
-  const [password, setPassword] = useState("");
-  const [passwordConfirm, setPasswordConfirm] = useState("");
+type PasswordStepProps = {
+  password: string;
+  passwordConfirm: string;
+  onChangePassword: (password: string) => void;
+  onChangePasswordConfirm: (password: string) => void;
+  handleSignUpAction: () => void;
+};
 
+const PasswordStep: FC<PasswordStepProps> = ({
+  password,
+  passwordConfirm,
+  onChangePassword,
+  onChangePasswordConfirm,
+  handleSignUpAction,
+}) => {
   const isLengthOk = password.length >= 8;
   const isMatch = password === passwordConfirm && passwordConfirm.length > 0;
   const canSubmit = isLengthOk && isMatch;
-  const handleSignUp = () => {
-    // TODO: 회원가입 API 연동
-  };
 
   const footer = (
     <Button
-      type="submit"
       className="w-full h-10"
       disabled={!canSubmit}
-      onClick={handleSignUp}
+      onClick={handleSignUpAction}
     >
       확인
     </Button>
@@ -36,7 +43,7 @@ const PasswordStep: FC = () => {
             autoComplete="new-password"
             minLength={8}
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => onChangePassword(e.target.value)}
             required
           />
           <Input
@@ -45,7 +52,7 @@ const PasswordStep: FC = () => {
             autoComplete="new-password"
             placeholder="비밀번호 확인"
             value={passwordConfirm}
-            onChange={(e) => setPasswordConfirm(e.target.value)}
+            onChange={(e) => onChangePasswordConfirm(e.target.value)}
           />
           {!isLengthOk && password.length > 0 && (
             <p className="text-xs text-red-500">

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -2,12 +2,19 @@ import AuthCard from "@/components/auth/AuthCard.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { type FC, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
+import { supabase } from "@/lib/supabaseClient.ts";
 
 const SignInForm: FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const handleSignIn = () => {
-    // TODO: 로그인 API 연동
+  const handleSignIn = async () => {
+    // TODO: 로그인 후 이전페이지로 이동, 사용자 정보 저장
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) console.error(error);
+    console.log(data);
   };
 
   const footer = (

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,22 +1,25 @@
 import AuthCard from "@/components/auth/AuthCard.tsx";
 import { Input } from "@/components/ui/input.tsx";
-import { type FC, useState } from "react";
+import { type FC } from "react";
 import { Button } from "@/components/ui/button.tsx";
-import { supabase } from "@/lib/supabaseClient.ts";
 
-const SignInForm: FC = () => {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const handleSignIn = async () => {
-    // TODO: 로그인 후 이전페이지로 이동, 사용자 정보 저장
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-    if (error) console.error(error);
-    console.log(data);
-  };
+type SignInFormProps = {
+  email: string;
+  password: string;
+  onChangeEmail: (email: string) => void;
+  onChangePassword: (password: string) => void;
+  handleSignIn: () => void;
+  errorMessage: string;
+};
 
+const SignInForm: FC<SignInFormProps> = ({
+  email,
+  password,
+  onChangeEmail,
+  onChangePassword,
+  handleSignIn,
+  errorMessage,
+}) => {
   const footer = (
     <Button className="w-full h-10" onClick={handleSignIn}>
       로그인
@@ -24,7 +27,7 @@ const SignInForm: FC = () => {
   );
 
   return (
-    <AuthCard footer={footer}>
+    <AuthCard footer={footer} errorMessage={errorMessage}>
       <form>
         <div className="flex flex-col gap-2">
           <Input
@@ -33,7 +36,7 @@ const SignInForm: FC = () => {
             placeholder="이메일"
             autoComplete="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => onChangeEmail(e.target.value)}
             required
           />
           <Input
@@ -42,7 +45,7 @@ const SignInForm: FC = () => {
             placeholder="비밀번호"
             autoComplete="current-password"
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => onChangePassword(e.target.value)}
             required
           />
         </div>

--- a/src/components/common/AuthProvider.tsx
+++ b/src/components/common/AuthProvider.tsx
@@ -1,0 +1,40 @@
+import { useEffect, type FC, type ReactNode } from "react";
+import type { Session } from "@supabase/supabase-js";
+import type { AuthSession } from "@/types/auth.ts";
+import { useSetAtom } from "jotai";
+import { authReadyAtom, sessionAtom } from "@/stores/authAtoms.ts";
+import { supabase } from "@/lib/supabaseClient.ts";
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+function mapSupabaseSession(session: Session | null): AuthSession | null {
+  if (!session) return null;
+  return {
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token ?? undefined,
+    expiresAt: session.expires_at ?? Math.floor(Date.now() / 1000) + 60 * 30,
+  };
+}
+
+export const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
+  const setSession = useSetAtom(sessionAtom);
+  const setAuthReady = useSetAtom(authReadyAtom);
+
+  useEffect(() => {
+    setAuthReady(false);
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(mapSupabaseSession(data.session));
+      setAuthReady(true);
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(mapSupabaseSession(session));
+    });
+
+    return () => sub.subscription.unsubscribe();
+  }, [setSession, setAuthReady]);
+
+  return <>{children}</>;
+};

--- a/src/components/header/DefaultHeader.tsx
+++ b/src/components/header/DefaultHeader.tsx
@@ -1,8 +1,11 @@
-import { type FC, useState } from "react";
-import { Button } from "@/components/ui/button.tsx";
+import { Button } from "@/components/ui/button";
+import { type FC } from "react";
+import { NavLink, useLocation } from "react-router";
+import { useAuth } from "@/hooks/useAuth.ts";
 
 const DefaultHeader: FC = () => {
-  const [isLogin] = useState(false);
+  const { isLogin, isAuthReady } = useAuth();
+  const location = useLocation();
   return (
     <>
       <div className="flex-1">
@@ -13,11 +16,16 @@ const DefaultHeader: FC = () => {
         </ul>
       </div>
       <div>
-        {isLogin ? (
-          <Button variant="default" size="sm">
-            로그인
-          </Button>
-        ) : (
+        {!isLogin && isAuthReady && (
+          <NavLink
+            to={`/signin?redirect=${encodeURIComponent(location.pathname)}`}
+          >
+            <Button variant="default" size="sm">
+              로그인
+            </Button>
+          </NavLink>
+        )}
+        {isLogin && isAuthReady && (
           <img
             className="rounded-md"
             src="/src/assets/profile.webp"

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,26 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  userAtom,
+  isAuthenticatedAtom,
+  authReadyAtom,
+  signInAtom,
+  signUpAtom,
+} from "@/stores/authAtoms";
+import type { LoginCredentials, SignUpCredentials } from "../types/auth";
+
+export const useAuth = () => {
+  const user = useAtomValue(userAtom);
+  const isLogin = useAtomValue(isAuthenticatedAtom);
+  const isAuthReady = useAtomValue(authReadyAtom);
+
+  const signIn = useSetAtom(signInAtom);
+  const signUp = useSetAtom(signUpAtom);
+
+  return {
+    user,
+    isLogin,
+    isAuthReady,
+    signIn: (credentials: LoginCredentials) => signIn(credentials),
+    signUp: (credentials: SignUpCredentials) => signUp(credentials),
+  };
+};

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = import.meta.env.DEV_URL;
+const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.DEV_URL;
-const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,11 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+// prod;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_PROD_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+// dev
+// const supabaseUrl = import.meta.env.VITE_SUPABASE_FUNCTIONS_DEV_URL;
+// const supabaseAnonKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router";
-import routes from './routes';
-import './index.css';
+import routes from "./routes";
+import "./index.css";
+import { AuthProvider } from "@/components/common/AuthProvider.tsx";
 
 const router = createBrowserRouter(routes);
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
+    <AuthProvider>
       <RouterProvider router={router} />,
+    </AuthProvider>
   </StrictMode>,
-)
+);

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -2,9 +2,10 @@ import AuthLayout from "@/layouts/AuthLayout.tsx";
 import { NavLink, useNavigate, useSearchParams } from "react-router";
 import SignInForm from "@/components/auth/SignInForm.tsx";
 import { useState } from "react";
-import { supabase } from "@/lib/supabaseClient.ts";
+import { useAuth } from "@/hooks/useAuth.ts";
 
 function SignIn() {
+  const { signIn } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const redirect = searchParams.get("redirect") || "/";
@@ -14,17 +15,14 @@ function SignIn() {
   const [errorMessage, setErrorMessage] = useState("");
 
   const handleSignIn = async () => {
-    // TODO: 사용자 정보 저장
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-    if (error) {
-      setErrorMessage("잘못된 정보를 입력하셨습니다.");
-      return;
+    setErrorMessage("");
+    const result = await signIn({ email, password });
+
+    if (result.success) {
+      navigate(redirect || "/", { replace: true });
+    } else {
+      setErrorMessage("잘못된 정보를 입력했습니다.");
     }
-    console.log(data);
-    return navigate(redirect, { replace: true });
   };
 
   const onChangeEmail = (email: string) => {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,8 +1,42 @@
 import AuthLayout from "@/layouts/AuthLayout.tsx";
-import { NavLink } from "react-router";
+import { NavLink, useNavigate, useSearchParams } from "react-router";
 import SignInForm from "@/components/auth/SignInForm.tsx";
+import { useState } from "react";
+import { supabase } from "@/lib/supabaseClient.ts";
 
 function SignIn() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/";
+  const redirectQuery = searchParams.get("redirect") || "/";
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleSignIn = async () => {
+    // TODO: 사용자 정보 저장
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      setErrorMessage("잘못된 정보를 입력하셨습니다.");
+      return;
+    }
+    console.log(data);
+    return navigate(redirect, { replace: true });
+  };
+
+  const onChangeEmail = (email: string) => {
+    setEmail(email);
+    if (errorMessage) setErrorMessage("");
+  };
+
+  const onChangePassword = (password: string) => {
+    setPassword(password);
+    if (errorMessage) setErrorMessage("");
+  };
+
   return (
     <AuthLayout>
       <div className="w-full flex flex-col items-center">
@@ -10,10 +44,19 @@ function SignIn() {
           <h1 className="text-4xl text-grey-opacity-800 font-semibold">
             로그인
           </h1>
-          <SignInForm />
+          <SignInForm
+            email={email}
+            password={password}
+            onChangeEmail={onChangeEmail}
+            onChangePassword={onChangePassword}
+            handleSignIn={handleSignIn}
+            errorMessage={errorMessage}
+          />
           <div className="text-sm space-x-1 font-medium">
             <span className="text-grey-opacity-500">아직 회원이 아닌가요?</span>
-            <NavLink to="/signup">
+            <NavLink
+              to={`/signup?redirect=${encodeURIComponent(redirectQuery)}`}
+            >
               <span className="underline underline-offset-2 text-blue-500 hover:bg-blue-500/10 p-1 rounded-sm cursor-pointer">
                 가입하기
               </span>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -12,10 +12,14 @@ function SignUp() {
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
 
+  const postSignUp = async (email: string, password: string) => {
+    const { data, error } = await supabase.auth.updateUser({ email, password });
+    if (error) return console.error(error);
+    return data;
+  };
+
   const signInWithOtp = async (email: string) => {
-    const { data, error } = await supabase.auth.signInWithOtp({
-      email,
-    });
+    const { data, error } = await supabase.auth.signInWithOtp({ email });
     if (error) return console.error(error);
     return data;
   };
@@ -30,8 +34,10 @@ function SignUp() {
     return data;
   };
 
-  const handleSignUpAction = () => {
-    // TODO: 회원가입 API 연동
+  const handleSignUpAction = async () => {
+    // TODO: 회원가입을 하면 이전페이지로 이동하고 전체 로그인 상태로 변경
+    const result = await postSignUp(email, password);
+    console.log(result);
   };
 
   const handleVerificationAction = async () => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -2,9 +2,47 @@ import AuthLayout from "@/layouts/AuthLayout.tsx";
 import { useState } from "react";
 import EmailCodeStep from "@/components/auth/EmailCodeStep.tsx";
 import PasswordStep from "@/components/auth/PasswordStep.tsx";
+import { supabase } from "@/lib/supabaseClient.ts";
 
 function SignUp() {
   const [isVerified, setIsVerified] = useState(false);
+  const [email, setEmail] = useState("");
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [verifyCode, setVerifyCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  const signInWithOtp = async (email: string) => {
+    const { data, error } = await supabase.auth.signInWithOtp({
+      email,
+    });
+    if (error) return console.error(error);
+    return data;
+  };
+
+  const verifyOtp = async (email: string, token: string) => {
+    const { data, error } = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: "email",
+    });
+    if (error) return console.error(error);
+    return data;
+  };
+
+  const handleSignUpAction = () => {
+    // TODO: 회원가입 API 연동
+  };
+
+  const handleVerificationAction = async () => {
+    if (!isCodeSent) {
+      const result = await signInWithOtp(email);
+      if (result) setIsCodeSent(true);
+    } else {
+      const result = await verifyOtp(email, verifyCode);
+      if (result) setIsVerified(true);
+    }
+  };
 
   return (
     <AuthLayout>
@@ -14,9 +52,22 @@ function SignUp() {
             회원가입
           </h1>
           {!isVerified ? (
-            <EmailCodeStep onChangeStep={() => setIsVerified(true)} />
+            <EmailCodeStep
+              email={email}
+              verifyCode={verifyCode}
+              isCodeSent={isCodeSent}
+              onChangeEmail={setEmail}
+              onChangeVerifyCode={setVerifyCode}
+              handleVerificationAction={handleVerificationAction}
+            />
           ) : (
-            <PasswordStep />
+            <PasswordStep
+              password={password}
+              passwordConfirm={passwordConfirm}
+              onChangePassword={setPassword}
+              onChangePasswordConfirm={setPasswordConfirm}
+              handleSignUpAction={handleSignUpAction}
+            />
           )}
         </div>
       </div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -4,9 +4,11 @@ import EmailCodeStep from "@/components/auth/EmailCodeStep.tsx";
 import PasswordStep from "@/components/auth/PasswordStep.tsx";
 import { supabase } from "@/lib/supabaseClient.ts";
 import { useNavigate, useSearchParams } from "react-router";
+import { useAuth } from "@/hooks/useAuth.ts";
 
 function SignUp() {
   const navigate = useNavigate();
+  const { signUp } = useAuth();
   const [searchParams] = useSearchParams();
   const redirect = searchParams.get("redirect") || "/";
   const [isVerified, setIsVerified] = useState(false);
@@ -16,12 +18,6 @@ function SignUp() {
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
-
-  const postSignUp = async (email: string, password: string) => {
-    const { data, error } = await supabase.auth.updateUser({ email, password });
-    if (error) return console.error(error);
-    return data;
-  };
 
   const signInWithOtp = async (email: string) => {
     const { data, error } = await supabase.auth.signInWithOtp({ email });
@@ -56,10 +52,14 @@ function SignUp() {
   };
 
   const handleSignUpAction = async () => {
-    // TODO: 전체 로그인 상태로 변경
-    const result = await postSignUp(email, password);
-    console.log(result);
-    return navigate(redirect, { replace: true });
+    setErrorMessage("");
+    const result = await signUp({ email, password });
+
+    if (result.success) {
+      return navigate(redirect, { replace: true });
+    } else {
+      setErrorMessage("회원가입이 실패했습니다.");
+    }
   };
 
   const handleVerificationAction = async () => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -3,8 +3,12 @@ import { useState } from "react";
 import EmailCodeStep from "@/components/auth/EmailCodeStep.tsx";
 import PasswordStep from "@/components/auth/PasswordStep.tsx";
 import { supabase } from "@/lib/supabaseClient.ts";
+import { useNavigate, useSearchParams } from "react-router";
 
 function SignUp() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/";
   const [isVerified, setIsVerified] = useState(false);
   const [email, setEmail] = useState("");
   const [isCodeSent, setIsCodeSent] = useState(false);
@@ -41,20 +45,21 @@ function SignUp() {
     return data;
   };
 
-  const onChangeEmail = (value: string) => {
-    setEmail(value);
+  const onChangeEmail = (email: string) => {
+    setEmail(email);
     if (errorMessage) setErrorMessage(""); // 에러 메시지 초기화
   };
 
-  const onChangeVerifyCode = (value: string) => {
-    setVerifyCode(value);
+  const onChangeVerifyCode = (verifyCode: string) => {
+    setVerifyCode(verifyCode);
     if (errorMessage) setErrorMessage("");
   };
 
   const handleSignUpAction = async () => {
-    // TODO: 회원가입을 하면 이전페이지로 이동하고 전체 로그인 상태로 변경
+    // TODO: 전체 로그인 상태로 변경
     const result = await postSignUp(email, password);
     console.log(result);
+    return navigate(redirect, { replace: true });
   };
 
   const handleVerificationAction = async () => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -11,6 +11,7 @@ function SignUp() {
   const [verifyCode, setVerifyCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
 
   const postSignUp = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.updateUser({ email, password });
@@ -20,7 +21,10 @@ function SignUp() {
 
   const signInWithOtp = async (email: string) => {
     const { data, error } = await supabase.auth.signInWithOtp({ email });
-    if (error) return console.error(error);
+    if (error) {
+      console.error(error);
+      return;
+    }
     return data;
   };
 
@@ -30,8 +34,21 @@ function SignUp() {
       token,
       type: "email",
     });
-    if (error) return console.error(error);
+    if (error) {
+      setErrorMessage("인증번호가 틀렸습니다.");
+      return;
+    }
     return data;
+  };
+
+  const onChangeEmail = (value: string) => {
+    setEmail(value);
+    if (errorMessage) setErrorMessage(""); // 에러 메시지 초기화
+  };
+
+  const onChangeVerifyCode = (value: string) => {
+    setVerifyCode(value);
+    if (errorMessage) setErrorMessage("");
   };
 
   const handleSignUpAction = async () => {
@@ -62,9 +79,10 @@ function SignUp() {
               email={email}
               verifyCode={verifyCode}
               isCodeSent={isCodeSent}
-              onChangeEmail={setEmail}
-              onChangeVerifyCode={setVerifyCode}
+              onChangeEmail={onChangeEmail}
+              onChangeVerifyCode={onChangeVerifyCode}
               handleVerificationAction={handleVerificationAction}
+              errorMessage={errorMessage}
             />
           ) : (
             <PasswordStep

--- a/src/stores/authAtoms.ts
+++ b/src/stores/authAtoms.ts
@@ -1,0 +1,98 @@
+import { atom } from "jotai";
+import { supabase } from "@/lib/supabaseClient";
+import type {
+  AuthSession,
+  AuthResult,
+  LoginCredentials,
+  SignUpCredentials,
+  AuthUser,
+} from "@/types/auth";
+import type { Session, User } from "@supabase/supabase-js";
+
+function mapSupabaseSession(session: Session | null): AuthSession | null {
+  if (!session) return null;
+  return {
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token ?? undefined,
+    expiresAt: session.expires_at ?? Math.floor(Date.now() / 1000) + 60 * 30,
+  };
+}
+
+function mapSupabaseUser(user: User | null): AuthUser | null {
+  if (!user) return null;
+  return {
+    id: user.id,
+    email: user.email || "",
+  };
+}
+
+export const authReadyAtom = atom<boolean>(false);
+
+export const sessionAtom = atom<AuthSession | null>(null);
+
+export const isAuthenticatedAtom = atom((get) => {
+  const session = get(sessionAtom);
+  return !!(session?.accessToken && session.expiresAt * 1000 > Date.now());
+});
+
+export const userAtom = atom<Promise<AuthUser | null>>(async (get) => {
+  const authed = get(isAuthenticatedAtom);
+  if (!authed) return null;
+
+  const { data, error } = await supabase.auth.getUser(); // 세션 기반으로 현재 유저 조회
+  if (error) throw error;
+
+  if (!data.user) return null;
+
+  return mapSupabaseUser(data.user);
+});
+
+export const signInAtom = atom(
+  null,
+  async (_get, set, credentials: LoginCredentials): Promise<AuthResult> => {
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email: credentials.email,
+        password: credentials.password,
+      });
+
+      if (error) throw error;
+
+      set(sessionAtom, mapSupabaseSession(data.session));
+
+      return {
+        success: true,
+        user: data.user,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Login failed";
+      console.error("Login error:", error);
+      return { success: false, error: errorMessage };
+    }
+  },
+);
+
+export const signUpAtom = atom(
+  null,
+  async (_get, _set, credentials: SignUpCredentials): Promise<AuthResult> => {
+    try {
+      const { data, error } = await supabase.auth.updateUser({
+        email: credentials.email,
+        password: credentials.password,
+      });
+
+      if (error) throw error;
+
+      return {
+        success: true,
+        user: data.user,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Sign up failed";
+      console.error("Sign up error:", error);
+      return { success: false, error: errorMessage };
+    }
+  },
+);

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,28 @@
+import type { User } from "@supabase/supabase-js";
+
+export type AuthUser = {
+  id: string;
+  email: string;
+};
+
+export type AuthSession = {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+};
+
+export type LoginCredentials = {
+  email: string;
+  password: string;
+};
+
+export type AuthResult = {
+  success: boolean;
+  error?: string;
+  user?: User | null;
+};
+
+export type SignUpCredentials = {
+  email: string;
+  password: string;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,21 @@
-import path from "path"
-import tailwindcss from "@tailwindcss/vite"
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import svgr from 'vite-plugin-svgr'
+import path from "path";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import svgr from "vite-plugin-svgr";
+import jotaiDebugLabel from "jotai/babel/plugin-debug-label";
+import jotaiReactRefresh from "jotai/babel/plugin-react-refresh";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss(), svgr()],
+  plugins: [
+    react({ babel: { plugins: [jotaiDebugLabel, jotaiReactRefresh] } }),
+    tailwindcss(),
+    svgr(),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
-})
+});


### PR DESCRIPTION
## ✨ 개요

<!-- 이번 PR에서 무엇을 했는지 간단히 설명 (ex: 회원가입 이메일 중복 검사 기능 추가) -->
로그인/회원가입/이메일 인증/인증번호 확인 Supabase Auth API 연동 및 Jotai 기반 유저 상태 관리 추가, 컴포넌트 상태 리프트



## 💡 변경 내용

<!-- 주요 변경사항을 요약해서 bullet point로 작성해주세요. -->

- supabase-js 설치 및 초기 세팅
- supabase URL env 변수명 변경
- SignUp에서 컴포넌트 상태 관리
- 이메일 OTP 전송/확인 연동
- SignIn에서 컴포넌트 상태관리
- 로그인/회원가입 성공시 이전 페이지로 이동 
- Jotai 라이브러리 설치 및 세팅
- Jotai user atoms 추가
- 회원가입/로그인 로직을 user atoms으로 이관
- useAuth 훅 제공
- supabase auth 유저 정보 스토리지로 저장
- AuthProvider 추가: getSession + onAuthStateChange 동기화
- Header에 로그인 상태 반영(버튼/아바타) 및 초기 깜빡임 제거


## 📸 스크린샷 (선택 사항)

<!-- UI/UX 변경 사항이 있을 경우, 관련 스크린샷이나 GIF를 Before / After 캡처를 첨부해주세요. -->


## 🧩 관련 이슈

<!-- PR과 관련된 이슈 번호를 링크하세요. -->

- Issue: #20 

## 🧐 리뷰어에게

<!-- 리뷰 시 중점적으로 확인할 부분이나 주의할 점을 작성해주세요 -->
SignUp, SignIn 상태 리프트 후 props 전달이 과하지 않은지, 전체적인 프로젝트 구조가 명확한지 확인해주세요.
Jotai를 올바르게 잘 사용하고 있는지와 추가로 리팩토링을 해야할 부분이 있는지 궁금합니다.



## ✅ Checklist

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  Self-Review를 완료했습니다.
- [x]  문서가 필요한 경우, 관련 문서를 업데이트했습니다.
