### PR TITLE
feat: 실시간 차트 랭킹 데이터 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@supabase/supabase-js": "^2.56.0",
         "@tailwindcss/vite": "^4.1.12",
+        "@tanstack/react-query": "^5.89.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "jotai": "^2.13.1",
@@ -2245,6 +2246,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.89.0.tgz",
+      "integrity": "sha512-joFV1MuPhSLsKfTzwjmPDrp8ENfZ9N23ymFu07nLfn3JCkSHy0CFgsyhHTJOmWaumC/WiNIKM0EJyduCF/Ih/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.89.0.tgz",
+      "integrity": "sha512-SXbtWSTSRXyBOe80mszPxpEbaN4XPRUp/i0EfQK1uyj3KCk/c8FuPJNIRwzOVe/OU3rzxrYtiNabsAmk1l714A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.89.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^7.8.2",
+        "react-use-websocket": "^4.13.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.12"
       },
@@ -4652,6 +4653,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-use-websocket": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.13.0.tgz",
+      "integrity": "sha512-anMuVoV//g2N76Wxqvqjjo1X48r9Np3y1/gMl7arX84tAPXdy5R7sB5lO5hvCzQRYjqXwV8XMAiEBOUbyrZFrw==",
+      "license": "MIT"
     },
     "node_modules/read-cmd-shim": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@supabase/supabase-js": "^2.56.0",
     "@tailwindcss/vite": "^4.1.12",
+    "@tanstack/react-query": "^5.89.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "jotai": "^2.13.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.8.2",
+    "react-use-websocket": "^4.13.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.12"
   },

--- a/src/apis/market.ts
+++ b/src/apis/market.ts
@@ -1,6 +1,6 @@
 import { supabase } from "@/lib/supabaseClient";
 
-export async function fetchMarketInfo(isoDate: string) {
+export const fetchMarketInfo = async (isoDate: string) => {
   const { data, error } = await supabase
     .from("market_calendar")
     .select("trade_date,open_time, close_time, session_open, session_close")
@@ -9,4 +9,4 @@ export async function fetchMarketInfo(isoDate: string) {
 
   if (error) throw error;
   return data;
-}
+};

--- a/src/apis/market.ts
+++ b/src/apis/market.ts
@@ -1,0 +1,12 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export async function fetchMarketInfo(isoDate: string) {
+  const { data, error } = await supabase
+    .from("market_calendar")
+    .select("trade_date,open_time, close_time, session_open, session_close")
+    .eq("trade_date", isoDate)
+    .single();
+
+  if (error) throw error;
+  return data;
+}

--- a/src/apis/market.ts
+++ b/src/apis/market.ts
@@ -5,7 +5,7 @@ export const fetchMarketInfo = async (isoDate: string) => {
     .from("market_calendar")
     .select("trade_date,open_time, close_time, session_open, session_close")
     .eq("trade_date", isoDate)
-    .single();
+    .maybeSingle();
 
   if (error) throw error;
   return data;

--- a/src/apis/ranking.ts
+++ b/src/apis/ranking.ts
@@ -1,0 +1,50 @@
+import { supabase } from "@/lib/supabaseClient";
+import type { Category, Period, RankingItem } from "@/types/ranking.ts";
+
+export async function fetchRankings(
+  metric: Category,
+  timeframe: Period,
+  limit = 100,
+): Promise<RankingItem[]> {
+  const { data, error } = await supabase
+    .from("rankings_live")
+    .select("*")
+    .eq("metric", metric)
+    .eq("timeframe", timeframe)
+    .order("rank", { ascending: true })
+    .limit(limit);
+
+  if (error) throw error;
+  return (data ?? []) as RankingItem[];
+}
+
+/**
+ * (metric, timeframe) 조합에 대한 Realtime 구독
+ */
+export function subscribeRankings(
+  metric: Category,
+  timeframe: Period,
+  limit: 100,
+  setRankings: (rows: RankingItem[]) => void,
+) {
+  const load = async () => {
+    const rows = await fetchRankings(metric, timeframe, limit);
+    setRankings(rows);
+  };
+
+  const channel = supabase
+    .channel(`rankings:${metric}:${timeframe}`)
+    .on("broadcast", { event: "updated" }, () => {
+      load();
+    })
+    .subscribe((status) => {
+      if (status === "SUBSCRIBED") {
+        // 초기 로드 한번
+        load();
+      }
+    });
+
+  return () => {
+    supabase.removeChannel(channel);
+  };
+}

--- a/src/components/ranking/RankingCategoryTabs.tsx
+++ b/src/components/ranking/RankingCategoryTabs.tsx
@@ -25,10 +25,10 @@ const RankingCategoryTabs: FC<RankingCategoryTabsProps> = ({
         <TabsTrigger variant="underline" value="volume">
           거래량
         </TabsTrigger>
-        <TabsTrigger variant="underline" value="gainers">
+        <TabsTrigger variant="underline" value="pct_up">
           급상승
         </TabsTrigger>
-        <TabsTrigger variant="underline" value="losers">
+        <TabsTrigger variant="underline" value="pct_down">
           급하락
         </TabsTrigger>
       </TabsList>

--- a/src/components/ranking/RankingPanel.tsx
+++ b/src/components/ranking/RankingPanel.tsx
@@ -1,198 +1,78 @@
-import { type FC, useState } from "react";
+import { type FC, useEffect, useMemo, useState } from "react";
 import RankingCategoryTabs from "@/components/ranking/RankingCategoryTabs.tsx";
 import {
   type Category,
   type Period,
   PERIODS_BY_CATEGORY,
+  type RankingItem,
 } from "@/types/ranking.ts";
 import RankingPeriodTabs from "@/components/ranking/RankingPeriodTabs.tsx";
 import RankingTable from "@/components/ranking/RankingTable.tsx";
 import MyPagination from "@/components/pagination/MyPagination.tsx";
 import { useNavigate, useSearchParams } from "react-router";
+import { subscribeRankings } from "@/apis/ranking.ts";
+import { useStockWebSocket } from "@/hooks/useStockWebSocket.ts";
+import { formatHHmm, formatMMDD } from "@/lib/utils.ts";
 
 const RankingPanel: FC = () => {
   const navigate = useNavigate();
+  const [updateDateTimeText, setUpdateDateTimeText] = useState("");
   const [searchParams] = useSearchParams();
-  // 임시 데이터
-  const stocks = [
-    {
-      rank: 1,
-      productCode: "US20180315001",
-      name: "지스케일러",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-ZS.png",
-      price: {
-        base: 274.57,
-        close: 279.18,
-        Volume: 305,
-        Amount: 118481891,
-      },
-      extraInfo: {
-        Buy: 1,
-        Sell: 305,
-      },
-    },
-    {
-      rank: 2,
-      productCode: "US20060713004",
-      name: "QID",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-QID.png?20240617",
-      price: {
-        base: 24.41,
-        close: 24.28,
-        Volume: 1651,
-        Amount: 55815676,
-      },
-      extraInfo: {
-        Buy: 1651,
-        Sell: 0,
-      },
-    },
-    {
-      rank: 3,
-      productCode: "US20220714004",
-      name: "NVDS",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-NVDS.png?20240715",
-      price: {
-        base: 12.75,
-        close: 12.83,
-        Volume: 2000,
-        Amount: 35784680,
-      },
-      extraInfo: {
-        Buy: 0,
-        Sell: 2000,
-      },
-    },
-    {
-      rank: 4,
-      productCode: "US20210611006",
-      name: "퀀텀 Si",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-QSI.png",
-      price: {
-        base: 1.08,
-        close: 1.09,
-        Volume: 23454,
-        Amount: 35269937,
-      },
-      extraInfo: {
-        Buy: 10,
-        Sell: 23454,
-      },
-    },
-    {
-      rank: 5,
-      productCode: "US20100311003",
-      name: "SOXS",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-SOXS.png?20240417",
-      price: {
-        base: 7.35,
-        close: 7.42,
-        Volume: 3409,
-        Amount: 35219641,
-      },
-      extraInfo: {
-        Buy: 3160,
-        Sell: 249,
-      },
-    },
-    {
-      rank: 6,
-      productCode: "US19971008002",
-      name: "TSMC(ADR)",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-NYS001Y70-E0.png?20240424",
-      price: {
-        base: 228.39,
-        close: 229.13,
-        Volume: 100,
-        Amount: 31753682,
-      },
-      extraInfo: {
-        Buy: 100,
-        Sell: 2,
-      },
-    },
-    {
-      rank: 7,
-      productCode: "NAS0250624007",
-      name: "OKLL",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-OKLL.png",
-      price: {
-        base: 29.9,
-        close: 30.26,
-        Volume: 722,
-        Amount: 30054926,
-      },
-      extraInfo: {
-        Buy: 25,
-        Sell: 697,
-      },
-    },
-    {
-      rank: 8,
-      productCode: "US20070530002",
-      name: "BIL",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-BIL.png?20240415",
-      price: {
-        base: 91.47,
-        close: 91.5,
-        Volume: 217,
-        Amount: 27637703,
-      },
-      extraInfo: {
-        Buy: 217,
-        Sell: 16,
-      },
-    },
-    {
-      rank: 9,
-      productCode: "AMX0240401004",
-      name: "BITU",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-BITU.png?20240617",
-      price: {
-        base: 50.94,
-        close: 50.8,
-        Volume: 300,
-        Amount: 21416876,
-      },
-      extraInfo: {
-        Buy: 5,
-        Sell: 300,
-      },
-    },
-    {
-      rank: 10,
-      productCode: "US20201208006",
-      name: "뉴스케일파워",
-      logoImageUrl:
-        "https://static.toss.im/png-icons/securities/icn-sec-fill-SMR.png",
-      price: {
-        base: 37.24,
-        close: 37.26,
-        Volume: 401,
-        Amount: 20993911,
-      },
-      extraInfo: {
-        Buy: 396,
-        Sell: 5,
-      },
-    },
-  ];
+  const [rankings, setRankings] = useState<RankingItem[]>([]);
+  const [rankingPageItems, setRankingPageItems] = useState<RankingItem[]>([]);
   const liveChart = searchParams.get("liveChart") || "notional";
   const [currentPage, setCurrentPage] = useState(1);
   const [rankingCategory, setRankingCategory] = useState(liveChart as Category);
   const rankingPeriods = PERIODS_BY_CATEGORY[rankingCategory];
+  const [loading, setLoading] = useState(false);
   const [selectedRankingPeriod, setSelectedRankingPeriod] = useState<Period>(
     rankingPeriods[0],
   );
+
+  const { rtSymbols } = useStockWebSocket(rankingPageItems);
+
+  const realTimeRankingItems = useMemo(
+    () =>
+      rankingPageItems.map((it) => {
+        const rtSymbol = rtSymbols
+          .filter((rtSym) => rtSym.symbol === it.symbol)
+          .pop();
+        return {
+          ...it,
+          rt_price: rtSymbol?.last,
+          rt_ts: rtSymbol?.ts,
+        };
+      }),
+    [rankingPageItems, rtSymbols],
+  );
+
+  useEffect(() => {
+    setLoading(false);
+
+    const unsubscribe = subscribeRankings(
+      rankingCategory,
+      selectedRankingPeriod,
+      100,
+      setRankings,
+    );
+
+    setCurrentPage(1);
+    return unsubscribe;
+  }, [rankingCategory, selectedRankingPeriod]);
+
+  useEffect(() => {
+    setRankingPageItems(
+      rankings.slice((currentPage - 1) * 10, currentPage * 10),
+    );
+    setUpdateDateTimeText(
+      rankings[0]
+        ? formatMMDD(new Date(rankings[0]?.updated_at)) +
+            " " +
+            formatHHmm(new Date(rankings[0]?.updated_at))
+        : "",
+    );
+    setLoading(true);
+  }, [rankings, currentPage]);
 
   const handleChangeRankingCategory = (next: Category) => {
     setRankingCategory(next);
@@ -207,7 +87,9 @@ const RankingPanel: FC = () => {
           <div className="text-[20px] font-semibold text-grey-800 p-2">
             실시간 차트
           </div>
-          <span className="text-sm text-grey-500">오늘 20:30 기준</span>
+          <span className="text-sm text-grey-500">
+            {updateDateTimeText} 기준
+          </span>
         </div>
         <div className="px-2 pt-2">
           <RankingCategoryTabs
@@ -224,16 +106,24 @@ const RankingPanel: FC = () => {
           />
         </div>
 
-        <div className="py-2">
-          <RankingTable stocks={stocks} />
-        </div>
+        {loading && (
+          <>
+            <div className="py-2">
+              <RankingTable
+                rankingPeriod={selectedRankingPeriod}
+                rankingCategory={rankingCategory}
+                rankingItems={realTimeRankingItems}
+              />
+            </div>
 
-        <div className="pt-4">
-          <MyPagination
-            currentPage={currentPage}
-            onCurrentPageChange={setCurrentPage}
-          />
-        </div>
+            <div className="pt-4">
+              <MyPagination
+                currentPage={currentPage}
+                onCurrentPageChange={setCurrentPage}
+              />
+            </div>
+          </>
+        )}
       </section>
     </div>
   );

--- a/src/components/ranking/RankingPanel.tsx
+++ b/src/components/ranking/RankingPanel.tsx
@@ -16,18 +16,27 @@ import { formatHHmm, formatMMDD } from "@/lib/utils.ts";
 
 const RankingPanel: FC = () => {
   const navigate = useNavigate();
-  const [updateDateTimeText, setUpdateDateTimeText] = useState("");
   const [searchParams] = useSearchParams();
   const [rankings, setRankings] = useState<RankingItem[]>([]);
-  const [rankingPageItems, setRankingPageItems] = useState<RankingItem[]>([]);
   const liveChart = searchParams.get("liveChart") || "notional";
   const [currentPage, setCurrentPage] = useState(1);
   const [rankingCategory, setRankingCategory] = useState(liveChart as Category);
   const rankingPeriods = PERIODS_BY_CATEGORY[rankingCategory];
-  const [loading, setLoading] = useState(false);
   const [selectedRankingPeriod, setSelectedRankingPeriod] = useState<Period>(
     rankingPeriods[0],
   );
+
+  const updateDateTimeText = useMemo(() => {
+    return rankings[0]
+      ? formatMMDD(new Date(rankings[0]?.updated_at)) +
+          " " +
+          formatHHmm(new Date(rankings[0]?.updated_at))
+      : "";
+  }, [rankings]);
+
+  const rankingPageItems = useMemo(() => {
+    return rankings.slice((currentPage - 1) * 10, currentPage * 10);
+  }, [rankings, currentPage]);
 
   const { rtSymbols } = useStockWebSocket(rankingPageItems);
 
@@ -47,8 +56,6 @@ const RankingPanel: FC = () => {
   );
 
   useEffect(() => {
-    setLoading(false);
-
     const unsubscribe = subscribeRankings(
       rankingCategory,
       selectedRankingPeriod,
@@ -60,25 +67,13 @@ const RankingPanel: FC = () => {
     return unsubscribe;
   }, [rankingCategory, selectedRankingPeriod]);
 
-  useEffect(() => {
-    setRankingPageItems(
-      rankings.slice((currentPage - 1) * 10, currentPage * 10),
-    );
-    setUpdateDateTimeText(
-      rankings[0]
-        ? formatMMDD(new Date(rankings[0]?.updated_at)) +
-            " " +
-            formatHHmm(new Date(rankings[0]?.updated_at))
-        : "",
-    );
-    setLoading(true);
-  }, [rankings, currentPage]);
-
   const handleChangeRankingCategory = (next: Category) => {
     setRankingCategory(next);
     setSelectedRankingPeriod(PERIODS_BY_CATEGORY[next][0]);
     return navigate("?liveChart=" + next, { replace: true });
   };
+
+  if (!rankingPageItems.length) return null;
 
   return (
     <div className="w-full">
@@ -97,7 +92,6 @@ const RankingPanel: FC = () => {
             onChangeRankingCategory={handleChangeRankingCategory}
           />
         </div>
-
         <div className="px-1 pt-2 pb-0.5">
           <RankingPeriodTabs
             selectedRankingPeriod={selectedRankingPeriod}
@@ -105,25 +99,20 @@ const RankingPanel: FC = () => {
             onRankingPeriodChange={setSelectedRankingPeriod}
           />
         </div>
+        <div className="py-2">
+          <RankingTable
+            rankingPeriod={selectedRankingPeriod}
+            rankingCategory={rankingCategory}
+            rankingItems={realTimeRankingItems}
+          />
+        </div>
 
-        {loading && (
-          <>
-            <div className="py-2">
-              <RankingTable
-                rankingPeriod={selectedRankingPeriod}
-                rankingCategory={rankingCategory}
-                rankingItems={realTimeRankingItems}
-              />
-            </div>
-
-            <div className="pt-4">
-              <MyPagination
-                currentPage={currentPage}
-                onCurrentPageChange={setCurrentPage}
-              />
-            </div>
-          </>
-        )}
+        <div className="pt-4">
+          <MyPagination
+            currentPage={currentPage}
+            onCurrentPageChange={setCurrentPage}
+          />
+        </div>
       </section>
     </div>
   );

--- a/src/components/ranking/RankingPeriodTabs.tsx
+++ b/src/components/ranking/RankingPeriodTabs.tsx
@@ -1,30 +1,12 @@
 import type { FC } from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs.tsx";
 import type { Period } from "@/types/ranking.ts";
+import { getPeriodText } from "@/lib/utils.ts";
 
 type RankingPeriodTabsProps = {
   selectedRankingPeriod: Period;
   rankingPeriods: Period[];
   onRankingPeriodChange: (period: Period) => void;
-};
-
-const getPeriodText = (period: Period) => {
-  switch (period) {
-    case "rt":
-      return "실시간";
-    case "1d":
-      return "1일";
-    case "7d":
-      return "1주일";
-    case "1m":
-      return "1개월";
-    case "3m":
-      return "3개월";
-    case "6m":
-      return "6개월";
-    default:
-      return "1년";
-  }
 };
 
 const RankingPeriodTabs: FC<RankingPeriodTabsProps> = ({

--- a/src/components/ranking/RankingRow.tsx
+++ b/src/components/ranking/RankingRow.tsx
@@ -1,6 +1,6 @@
 import { TableCell, TableRow } from "@/components/ui/table.tsx";
 import { cn, commaFormat, getNotionalText } from "@/lib/utils.ts";
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, useEffect, useMemo, useRef, useState } from "react";
 import type { RankingItem } from "@/types/ranking.ts";
 
 type RankingRowProps = {
@@ -12,13 +12,13 @@ const ZEBRA_BG = "bg-[#F9FAFB]";
 
 const RankingRow: FC<RankingRowProps> = ({ stock }) => {
   const prevPctRef = useRef<number | null>(null);
+  const [flashClass, setFlashClass] = useState("");
   const stockPrice = stock.rt_price ?? stock.current_price;
   const 등락률 = ((stockPrice - stock.anchor_price) / stock.anchor_price) * 100;
   const fixed = Math.abs(등락률) >= 0.1 ? 1 : 2;
   const numberSign = 등락률 > 0 ? "+" : "";
   const 등락률Text = numberSign + 등락률.toFixed(fixed);
 
-  const [flashClass, setFlashClass] = useState("");
   const changeTextClass = 등락률 > 0 ? "text-red-500" : "text-blue-600";
   const rowClass = cn(ROW_BASE, stock.rank % 2 === 1 && ZEBRA_BG);
   const changeClass = cn(changeTextClass);
@@ -26,13 +26,20 @@ const RankingRow: FC<RankingRowProps> = ({ stock }) => {
     ? "grid grid-cols-4"
     : "grid grid-cols-5";
 
-  useEffect(() => {
+  const 등락률flash = useMemo(() => {
     const prev = prevPctRef.current;
     prevPctRef.current = 등락률;
-    if (prev === null || 등락률 === 0) return;
-    if (prev.toFixed(fixed) === 등락률.toFixed(fixed)) return;
-    setFlashClass(등락률 > 0 ? "flash-up" : "flash-down");
-  }, [등락률]);
+    if (prev === null || 등락률 === 0) return "";
+    if (prev.toFixed(fixed) === 등락률.toFixed(fixed)) return "";
+    return 등락률 > 0 ? "flash-up" : "flash-down";
+  }, [등락률, fixed]);
+
+  useEffect(() => {
+    if (!등락률flash) return;
+    setFlashClass("");
+    const id = requestAnimationFrame(() => setFlashClass(등락률flash));
+    return () => cancelAnimationFrame(id);
+  }, [등락률flash]);
 
   return (
     <TableRow key={stock.rank} className={cn(rowClass, gridCols)}>
@@ -49,20 +56,19 @@ const RankingRow: FC<RankingRowProps> = ({ stock }) => {
         <div
           className={cn(
             flashClass,
-            "py-0.5 rounded-[6px] min-w-[91px] flex justify-end px-2 min-w-[91px] h-7",
+            "py-0.5 rounded-[6px] min-w-[91px] flex justify-end px-1 h-7",
           )}
-          onAnimationEnd={() => setFlashClass("")}
         >
           {등락률Text}%
         </div>
       </TableCell>
       {stock.metric === "notional" && (
-        <TableCell className="justify-end col-span-1">
+        <TableCell className="justify-end col-span-1 px-2">
           {getNotionalText(stock.value)}
         </TableCell>
       )}
       {stock.metric === "volume" && (
-        <TableCell className="justify-end col-span-1">
+        <TableCell className="justify-end col-span-1 px-2">
           {commaFormat(stock.value)}주
         </TableCell>
       )}

--- a/src/components/ranking/RankingRow.tsx
+++ b/src/components/ranking/RankingRow.tsx
@@ -1,37 +1,71 @@
 import { TableCell, TableRow } from "@/components/ui/table.tsx";
-import { cn } from "@/lib/utils.ts";
-import type { FC } from "react";
-import type { Stock } from "@/types/ranking.ts";
+import { cn, commaFormat, getNotionalText } from "@/lib/utils.ts";
+import { type FC, useEffect, useRef, useState } from "react";
+import type { RankingItem } from "@/types/ranking.ts";
 
 type RankingRowProps = {
-  stock: Stock;
+  stock: RankingItem;
 };
 
 const ROW_BASE = "border-none text-gray-800 cursor-pointer";
 const ZEBRA_BG = "bg-[#F9FAFB]";
 
 const RankingRow: FC<RankingRowProps> = ({ stock }) => {
-  const 등락률 =
-    ((stock.price.close - stock.price.base) / stock.price.base) * 100;
+  const prevPctRef = useRef<number | null>(null);
+  const stockPrice = stock.rt_price ?? stock.current_price;
+  const 등락률 = ((stockPrice - stock.anchor_price) / stock.anchor_price) * 100;
   const fixed = Math.abs(등락률) >= 0.1 ? 1 : 2;
-  const 등락률Text = (Math.round(등락률 * fixed * 10) / (fixed * 10)).toFixed(
-    fixed,
-  );
+  const numberSign = 등락률 > 0 ? "+" : "";
+  const 등락률Text = numberSign + 등락률.toFixed(fixed);
 
+  const [flashClass, setFlashClass] = useState("");
   const changeTextClass = 등락률 > 0 ? "text-red-500" : "text-blue-600";
   const rowClass = cn(ROW_BASE, stock.rank % 2 === 1 && ZEBRA_BG);
-  const changeClass = cn(changeTextClass, "text-right");
+  const changeClass = cn(changeTextClass);
+  const gridCols = ["pct_up", "pct_down"].includes(stock.metric)
+    ? "grid grid-cols-4"
+    : "grid grid-cols-5";
+
+  useEffect(() => {
+    const prev = prevPctRef.current;
+    prevPctRef.current = 등락률;
+    if (prev === null || 등락률 === 0) return;
+    if (prev.toFixed(fixed) === 등락률.toFixed(fixed)) return;
+    setFlashClass(등락률 > 0 ? "flash-up" : "flash-down");
+  }, [등락률]);
 
   return (
-    <TableRow key={stock.rank} className={rowClass}>
-      <TableCell className="font-medium">
+    <TableRow key={stock.rank} className={cn(rowClass, gridCols)}>
+      <TableCell className="justify-start font-medium col-span-2">
         <div className="flex">
           <div className="min-w-7 mx-2">{stock.rank}</div>
-          <div>{stock.name}</div>
+          <div>{stock.symbol}</div>
         </div>
       </TableCell>
-      <TableCell className="text-right">${stock.price.base}</TableCell>
-      <TableCell className={changeClass}>{등락률Text}%</TableCell>
+      <TableCell className="justify-end col-span-1">
+        <div className="px-1">${stockPrice.toFixed(2)}</div>
+      </TableCell>
+      <TableCell className={cn(changeClass, "justify-end col-span-1")}>
+        <div
+          className={cn(
+            flashClass,
+            "py-0.5 rounded-[6px] min-w-[91px] flex justify-end px-2 min-w-[91px] h-7",
+          )}
+          onAnimationEnd={() => setFlashClass("")}
+        >
+          {등락률Text}%
+        </div>
+      </TableCell>
+      {stock.metric === "notional" && (
+        <TableCell className="justify-end col-span-1">
+          {getNotionalText(stock.value)}
+        </TableCell>
+      )}
+      {stock.metric === "volume" && (
+        <TableCell className="justify-end col-span-1">
+          {commaFormat(stock.value)}주
+        </TableCell>
+      )}
     </TableRow>
   );
 };

--- a/src/components/ranking/RankingTable.tsx
+++ b/src/components/ranking/RankingTable.tsx
@@ -46,13 +46,13 @@ const RankingTable: FC<RankingTableProps> = ({
           {!["pct_up", "pct_down"].includes(rankingCategory) && (
             <TableHead className="text-right col-span-1">등락률</TableHead>
           )}
-          <TableHead className="text-right font-semibold text-blue-500 col-span-1">
+          <TableHead className="text-right font-medium text-blue-500 col-span-1">
             {rankingHeadName}
           </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {rankingItems.map((stock: RankingItem) => (
+        {rankingItems.map((stock) => (
           <RankingRow key={stock.rank} stock={stock} />
         ))}
       </TableBody>

--- a/src/components/ranking/RankingTable.tsx
+++ b/src/components/ranking/RankingTable.tsx
@@ -6,25 +6,53 @@ import {
   TableRow,
 } from "@/components/ui/table.tsx";
 import type { FC } from "react";
-import type { Stock } from "@/types/ranking.ts";
+import type { Category, Period, RankingItem } from "@/types/ranking.ts";
 import RankingRow from "@/components/ranking/RankingRow.tsx";
+import { cn, getPeriodText } from "@/lib/utils.ts";
 
 type RankingTableProps = {
-  stocks: Stock[];
+  rankingPeriod: Period;
+  rankingCategory: Category;
+  rankingItems: RankingItem[];
 };
 
-const RankingTable: FC<RankingTableProps> = ({ stocks }) => {
+const HEAD_CATEGORIES = {
+  notional: "거래대금 많은 순",
+  volume: "거래량 많은 순",
+  pct_up: "등락률 높은 순",
+  pct_down: "등락률 낮은 순",
+} as const;
+
+const RankingTable: FC<RankingTableProps> = ({
+  rankingPeriod,
+  rankingCategory,
+  rankingItems,
+}) => {
+  const rankingHeadName =
+    (rankingPeriod === "RT" ? "" : getPeriodText(rankingPeriod)) +
+    " " +
+    HEAD_CATEGORIES[rankingCategory];
+
+  const gridCols = ["pct_up", "pct_down"].includes(rankingCategory)
+    ? "grid grid-cols-4"
+    : "grid grid-cols-5";
+
   return (
     <Table>
       <TableHeader>
-        <TableRow className="hover:bg-transparent border-none">
-          <TableHead>종목</TableHead>
-          <TableHead className="text-right">현재가</TableHead>
-          <TableHead className="text-right">등락률</TableHead>
+        <TableRow className={cn("hover:bg-transparent border-none", gridCols)}>
+          <TableHead className="text-left col-span-2">종목</TableHead>
+          <TableHead className="text-right col-span-1">현재가</TableHead>
+          {!["pct_up", "pct_down"].includes(rankingCategory) && (
+            <TableHead className="text-right col-span-1">등락률</TableHead>
+          )}
+          <TableHead className="text-right font-semibold text-blue-500 col-span-1">
+            {rankingHeadName}
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {stocks.map((stock: Stock) => (
+        {rankingItems.map((stock: RankingItem) => (
           <RankingRow key={stock.rank} stock={stock} />
         ))}
       </TableBody>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-grey-opacity-100 data-[state=selected]:bg-muted border-b transition-colors px-1 py-1.5",
+        "h-11 flex items-center hover:bg-grey-opacity-100 data-[state=selected]:bg-muted border-b transition-colors px-1",
         className,
       )}
       {...props}
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-muted-foreground h-10 px-2 text-left align-middle font-normal whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-2 text-muted-foreground align-middle font-normal whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "rounded-[6px] px-2 py-2.5 align-middle text-[15px] whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "flex px-1 py-1.5 text-[15px] whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -25,7 +25,7 @@ const tabsTriggerVariants = cva("inline-flex items-center justify-center", {
       default:
         "cursor-pointer relative z-10 dark:data-[state=active]:text-foreground data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-muted-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-[6px] border border-transparent px-2 py-1 text-sm whitespace-nowrap focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
       underline:
-        "cursor-pointer relative h-9 whitespace-nowrap text-[15px] ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 rounded-none bg-transparent mr-5 py-2.5 text-muted-foreground shadow-none data-[state=active]:text-foreground",
+        "cursor-pointer relative h-9 whitespace-nowrap text-[15px] ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 rounded-none bg-transparent mr-5 py-2.5 text-grey-opacity-800 data-[state=active]:font-medium shadow-none",
       // Add more variants here
     },
   },

--- a/src/hooks/useMarketInfo.ts
+++ b/src/hooks/useMarketInfo.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchMarketInfo } from "@/apis/market.ts";
+
+type MarketInfo = {
+  startDateTime: Date | null;
+  endDateTime: Date | null;
+  marketName: "프리마켓" | "정규장" | "애프터마켓" | "장 닫힘";
+};
+
+type MarketCalendarRow = {
+  trade_date: string;
+  session_open: string;
+  open_time: string;
+  close_time: string;
+  session_close: string;
+};
+
+export const useMarketInfo = () => {
+  const [rowData, setRowData] = useState<MarketCalendarRow | undefined>();
+  const isoDate = new Date().toISOString().slice(0, 10);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+        const result = await fetchMarketInfo(isoDate);
+        setRowData(result);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [isoDate]);
+
+  const marketInfo: MarketInfo | undefined = useMemo(() => {
+    if (!rowData) return;
+    const isoDateTime = new Date();
+    const session_open = new Date(rowData.session_open);
+    const open_time = new Date(rowData.open_time);
+    const close_time = new Date(rowData.close_time);
+    const session_close = new Date(rowData.session_close);
+
+    if (isoDateTime < session_open)
+      return {
+        startDateTime: null,
+        endDateTime: new Date(session_open),
+        marketName: "장 닫힘",
+      };
+    if (isoDateTime < open_time)
+      return {
+        startDateTime: new Date(session_open),
+        endDateTime: new Date(open_time),
+        marketName: "프리마켓",
+      };
+    if (isoDateTime < close_time)
+      return {
+        startDateTime: new Date(open_time),
+        endDateTime: new Date(close_time),
+        marketName: "정규장",
+      };
+    if (isoDateTime < session_close)
+      return {
+        startDateTime: new Date(close_time),
+        endDateTime: new Date(session_close),
+        marketName: "애프터마켓",
+      };
+    return {
+      startDateTime: new Date(session_close),
+      endDateTime: null,
+      marketName: "장 닫힘",
+    };
+  }, [rowData]);
+
+  return { loading, marketInfo };
+};

--- a/src/hooks/useMarketInfo.ts
+++ b/src/hooks/useMarketInfo.ts
@@ -1,19 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { fetchMarketInfo } from "@/apis/market.ts";
-
-type MarketInfo = {
-  startDateTime: Date | null;
-  endDateTime: Date | null;
-  marketName: "프리마켓" | "정규장" | "애프터마켓" | "장 닫힘";
-};
-
-type MarketCalendarRow = {
-  trade_date: string;
-  session_open: string;
-  open_time: string;
-  close_time: string;
-  session_close: string;
-};
+import type { MarketCalendarRow, MarketInfo } from "@/types/market.ts";
 
 export const useMarketInfo = () => {
   const [rowData, setRowData] = useState<MarketCalendarRow | undefined>();

--- a/src/hooks/useMarketInfo.ts
+++ b/src/hooks/useMarketInfo.ts
@@ -1,33 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { fetchMarketInfo } from "@/apis/market.ts";
-import type { MarketCalendarRow, MarketInfo } from "@/types/market.ts";
+import type { MarketInfo } from "@/types/market.ts";
+import { useQuery } from "@tanstack/react-query";
 
 export const useMarketInfo = () => {
-  const [rowData, setRowData] = useState<MarketCalendarRow | undefined>();
   const isoDate = new Date().toISOString().slice(0, 10);
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        setLoading(true);
-        const result = await fetchMarketInfo(isoDate);
-        setRowData(result);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [isoDate]);
+  const { data: marketInfoData, isLoading } = useQuery({
+    queryKey: ["marketInfo", isoDate],
+    queryFn: () => fetchMarketInfo(isoDate),
+  });
 
   const marketInfo: MarketInfo | undefined = useMemo(() => {
-    if (!rowData) return;
+    if (!marketInfoData) return;
     const isoDateTime = new Date();
-    const session_open = new Date(rowData.session_open);
-    const open_time = new Date(rowData.open_time);
-    const close_time = new Date(rowData.close_time);
-    const session_close = new Date(rowData.session_close);
+    const session_open = new Date(marketInfoData.session_open);
+    const open_time = new Date(marketInfoData.open_time);
+    const close_time = new Date(marketInfoData.close_time);
+    const session_close = new Date(marketInfoData.session_close);
 
     if (isoDateTime < session_open)
       return {
@@ -58,7 +48,7 @@ export const useMarketInfo = () => {
       endDateTime: null,
       marketName: "장 닫힘",
     };
-  }, [rowData]);
+  }, [marketInfoData]);
 
-  return { loading, marketInfo };
+  return { isMarketInfoLoading: isLoading, marketInfo };
 };

--- a/src/hooks/useMarketInfo.ts
+++ b/src/hooks/useMarketInfo.ts
@@ -12,7 +12,13 @@ export const useMarketInfo = () => {
   });
 
   const marketInfo: MarketInfo | undefined = useMemo(() => {
-    if (!marketInfoData) return;
+    if (!marketInfoData) {
+      return {
+        startDateTime: null,
+        endDateTime: null,
+        marketName: "장 닫힘",
+      };
+    }
     const isoDateTime = new Date();
     const session_open = new Date(marketInfoData.session_open);
     const open_time = new Date(marketInfoData.open_time);

--- a/src/hooks/useStockWebSocket.ts
+++ b/src/hooks/useStockWebSocket.ts
@@ -46,17 +46,18 @@ export const useStockWebSocket = (rankingPageItems: RankingItem[]) => {
     const next = rankingPageItems.map(
       (stockInfo: RankingItem) => stockInfo.symbol,
     );
+
     const prev = prevSymbolsRef.current;
     const added = next.filter((sym: string) => !prev.includes(sym));
     const removed = prev.filter((sym: string) => !next.includes(sym));
 
-    if (removed.length) {
+    if (removed.length > 0) {
       sendJsonMessage({
         action: "unsubscribe",
         trades: removed,
       });
     }
-    if (added.length) {
+    if (added.length > 0) {
       sendJsonMessage({
         action: "subscribe",
         trades: added,
@@ -64,19 +65,8 @@ export const useStockWebSocket = (rankingPageItems: RankingItem[]) => {
     }
 
     prevSymbolsRef.current = next;
+    lastMessages.current = [];
   }, [rankingPageItems, readyState, sendJsonMessage]);
-
-  useEffect(() => {
-    return () => {
-      const cur = prevSymbolsRef.current;
-      if (cur.length && readyState === ReadyState.OPEN) {
-        sendJsonMessage({
-          action: "unsubscribe",
-          trades: cur,
-        });
-      }
-    };
-  }, [readyState, sendJsonMessage]);
 
   useEffect(() => {
     if (!lastJsonMessage) return;
@@ -85,7 +75,12 @@ export const useStockWebSocket = (rankingPageItems: RankingItem[]) => {
       : [lastJsonMessage];
 
     // 소켓 에러일 때 강제 새로고침
-    if (msgs[0].T === "error") window.location.reload();
+    if (msgs[0].T === "error") {
+      window.location.reload();
+    }
+    if (msgs[0].T === "success" && msgs[0].msg === "authenticated") {
+      authedRef.current = true;
+    }
 
     const prevMessages = lastMessages.current;
     lastMessages.current = [...prevMessages, ...msgs];
@@ -96,6 +91,7 @@ export const useStockWebSocket = (rankingPageItems: RankingItem[]) => {
       setRTSymbols((prev) => {
         const next = [...prev];
         const messages = lastMessages.current;
+
         for (const msg of messages) {
           if (msg.T !== "t") continue;
           const sym = msg.S;

--- a/src/hooks/useStockWebSocket.ts
+++ b/src/hooks/useStockWebSocket.ts
@@ -1,0 +1,120 @@
+import useWebSocket, { ReadyState } from "react-use-websocket";
+import { useEffect, useRef, useState } from "react";
+import type { RankingItem } from "@/types/ranking.ts";
+
+const WS_URL = "wss://stream.data.alpaca.markets/v2/delayed_sip";
+type RTRow = { symbol: string; last?: number; size?: number; ts?: string };
+type MSGRow = {
+  S: string;
+  T: string;
+  c: Array<string>;
+  i: number;
+  p: number;
+  s: number;
+  t: string;
+};
+
+export const useStockWebSocket = (rankingPageItems: RankingItem[]) => {
+  const prevSymbolsRef = useRef<string[]>([]);
+  const authedRef = useRef(false);
+  const lastMessages = useRef<MSGRow[]>([]);
+  const [rtSymbols, setRTSymbols] = useState<RTRow[]>([]);
+
+  const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(
+    WS_URL,
+    {
+      share: true,
+      retryOnError: true, // 에러 발생 시 다시 구동
+      shouldReconnect: () => true, // 지정된 간격으로 연결 다시 시도
+      reconnectInterval: (n) => Math.min(1000 * 2 ** n, 10000), // 간격
+    },
+  );
+
+  useEffect(() => {
+    if (readyState !== ReadyState.OPEN || authedRef.current) return;
+
+    sendJsonMessage({
+      action: "auth",
+      key: import.meta.env.VITE_ALPACA_KEY,
+      secret: import.meta.env.VITE_ALPACA_SECRET_KEY,
+    });
+  }, [readyState, sendJsonMessage]);
+
+  useEffect(() => {
+    if (readyState !== ReadyState.OPEN) return;
+
+    const next = rankingPageItems.map(
+      (stockInfo: RankingItem) => stockInfo.symbol,
+    );
+    const prev = prevSymbolsRef.current;
+    const added = next.filter((sym: string) => !prev.includes(sym));
+    const removed = prev.filter((sym: string) => !next.includes(sym));
+
+    if (removed.length) {
+      sendJsonMessage({
+        action: "unsubscribe",
+        trades: removed,
+      });
+    }
+    if (added.length) {
+      sendJsonMessage({
+        action: "subscribe",
+        trades: added,
+      });
+    }
+
+    prevSymbolsRef.current = next;
+  }, [rankingPageItems, readyState, sendJsonMessage]);
+
+  useEffect(() => {
+    return () => {
+      const cur = prevSymbolsRef.current;
+      if (cur.length && readyState === ReadyState.OPEN) {
+        sendJsonMessage({
+          action: "unsubscribe",
+          trades: cur,
+        });
+      }
+    };
+  }, [readyState, sendJsonMessage]);
+
+  useEffect(() => {
+    if (!lastJsonMessage) return;
+    const msgs = Array.isArray(lastJsonMessage)
+      ? lastJsonMessage
+      : [lastJsonMessage];
+
+    // 소켓 에러일 때 강제 새로고침
+    if (msgs[0].T === "error") window.location.reload();
+
+    const prevMessages = lastMessages.current;
+    lastMessages.current = [...prevMessages, ...msgs];
+  }, [lastJsonMessage]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRTSymbols((prev) => {
+        const next = [...prev];
+        const messages = lastMessages.current;
+        for (const msg of messages) {
+          if (msg.T !== "t") continue;
+          const sym = msg.S;
+          const idx = next.findIndex((r) => r.symbol === sym);
+          const upd: RTRow = {
+            symbol: msg.S,
+            last: msg.p,
+            size: msg.s,
+            ts: msg.t,
+          };
+          if (idx >= 0) next[idx] = { ...upd };
+          else next.push(upd);
+        }
+        return next;
+      });
+    }, 500);
+
+    return () => clearInterval(id);
+  }, []);
+
+  return { rtSymbols };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -167,3 +167,28 @@
   }
 }
 
+리@keyframes flash-up {
+  from { background-color: #ff889050; } /* tailwind red-50 */
+  to   { background-color: transparent; }
+}
+
+@keyframes flash-down {
+  from { background-color: #64A8FF50; } /* tailwind blue-50 */
+  to   { background-color: transparent; }
+}
+
+@keyframes fade-up {
+  0% { opacity: 0; transform: translateY(100%); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fade-down {
+  0% { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(100%); }
+}
+
+.fade-up { position: relative; animation: fade-up 1s; }
+.fade-down { position: relative; animation: fade-down 1s; }
+.flash-up   { animation: flash-up 1000ms ease-out; }
+.flash-down { animation: flash-down 1000ms ease-out; }
+

--- a/src/index.css
+++ b/src/index.css
@@ -167,7 +167,7 @@
   }
 }
 
-리@keyframes flash-up {
+@keyframes flash-up {
   from { background-color: #ff889050; } /* tailwind red-50 */
   to   { background-color: transparent; }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,18 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { Period } from "@/types/ranking.ts";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const formatHHmm = (d: Date) => {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+};
+
+export const formatMMDD = (d: Date) => {
+  return `${String(d.getMonth() + 1)}월 ${String(d.getDate())}일`;
+};
 
 export const range = (n: number): number[] =>
   n > 0 ? Array.from({ length: n }, (_, i) => i + 1) : [];
@@ -12,3 +21,41 @@ export const rangeInclusive = (start: number, end: number): number[] =>
   end >= start
     ? Array.from({ length: end - start + 1 }, (_, i) => start + i)
     : [];
+
+export function commaFormat(number: number | undefined | null): string {
+  if (number === undefined || number === null) {
+    return "0";
+  }
+  return number.toLocaleString("en-US");
+}
+
+export const getNotionalText = (value: number) => {
+  if (value < 10000000) {
+    return commaFormat(Math.round(value));
+  } else if (value < 100000000) {
+    return commaFormat(Math.round(value / 1000)) + "만";
+  } else if (value < 1000000000000) {
+    return commaFormat(Math.round(value / 10000000) / 10) + "억";
+  } else {
+    return commaFormat(Math.round(value / 100000000000) / 10) + "조";
+  }
+};
+
+export const getPeriodText = (period: Period) => {
+  switch (period) {
+    case "RT":
+      return "실시간";
+    case "1D":
+      return "1일";
+    case "7D":
+      return "1주일";
+    case "1M":
+      return "1개월";
+    case "3M":
+      return "3개월";
+    case "6M":
+      return "6개월";
+    default:
+      return "1년";
+  }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,17 @@ import { createBrowserRouter, RouterProvider } from "react-router";
 import routes from "./routes.tsx";
 import "./index.css";
 import { AuthProvider } from "@/components/common/AuthProvider.tsx";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const router = createBrowserRouter(routes);
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AuthProvider>
-      <RouterProvider router={router} />,
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <RouterProvider router={router} />,
+      </AuthProvider>
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,7 +17,7 @@ function Home() {
     <div className="w-full py-4 px-[clamp(16px,_calc(10vw_-_112px),_32px)]">
       <div className="min-w-[1100px] max-w-[1280px] mx-auto">
         <section className="flex py-4 px-2">
-          <span className="flex px-2.5 justify-center items-center">
+          <span className="flex pr-2.5 justify-center items-center">
             <div
               className={cn(marketOpenBgClass, "w-1.5 h-1.5 rounded-full")}
             ></div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,13 +3,15 @@ import { useMarketInfo } from "@/hooks/useMarketInfo.ts";
 import { cn } from "@/lib/utils.ts";
 
 function Home() {
-  const { marketInfo } = useMarketInfo();
+  const { isMarketInfoLoading, marketInfo } = useMarketInfo();
   const marketOpenBgClass =
     marketInfo?.marketName === "장 닫힘" ? "bg-grey-400" : "bg-green-700";
   const marketOpenTextClass =
     marketInfo?.marketName === "장 닫힘"
       ? "text-grey-opacity-500"
       : "text-grey-opacity-800 font-semibold";
+
+  if (isMarketInfoLoading) return null;
 
   return (
     <div className="w-full py-4 px-[clamp(16px,_calc(10vw_-_112px),_32px)]">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,28 @@
 import RankingPanel from "@/components/ranking/RankingPanel.tsx";
+import { useMarketInfo } from "@/hooks/useMarketInfo.ts";
+import { cn } from "@/lib/utils.ts";
 
 function Home() {
+  const { marketInfo } = useMarketInfo();
+  const marketOpenBgClass =
+    marketInfo?.marketName === "장 닫힘" ? "bg-grey-400" : "bg-green-700";
+  const marketOpenTextClass =
+    marketInfo?.marketName === "장 닫힘"
+      ? "text-grey-opacity-500"
+      : "text-grey-opacity-800 font-semibold";
+
   return (
     <div className="w-full py-4 px-[clamp(16px,_calc(10vw_-_112px),_32px)]">
       <div className="min-w-[1100px] max-w-[1280px] mx-auto">
-        <section className="flex gap-x-6 py-4 px-2">
-          <span className="text-sm text-grey-500">국내 장 닫힘</span>
-          <span className="text-sm">해외 프리마켓</span>
+        <section className="flex py-4 px-2">
+          <span className="flex px-2.5 justify-center items-center">
+            <div
+              className={cn(marketOpenBgClass, "w-1.5 h-1.5 rounded-full")}
+            ></div>
+          </span>
+          <span className={cn(marketOpenTextClass, "text-sm")}>
+            해외 {marketInfo?.marketName}
+          </span>
         </section>
         <div className="flex">
           <section className="max-w-[840px] min-w-[690px]">

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -3,11 +3,3 @@ export type MarketInfo = {
   endDateTime: Date | null;
   marketName: "프리마켓" | "정규장" | "애프터마켓" | "장 닫힘";
 };
-
-export type MarketCalendarRow = {
-  trade_date: string;
-  session_open: string;
-  open_time: string;
-  close_time: string;
-  session_close: string;
-};

--- a/src/types/market.ts
+++ b/src/types/market.ts
@@ -1,0 +1,13 @@
+export type MarketInfo = {
+  startDateTime: Date | null;
+  endDateTime: Date | null;
+  marketName: "프리마켓" | "정규장" | "애프터마켓" | "장 닫힘";
+};
+
+export type MarketCalendarRow = {
+  trade_date: string;
+  session_open: string;
+  open_time: string;
+  close_time: string;
+  session_close: string;
+};

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -1,27 +1,25 @@
-export type Category = "notional" | "volume" | "gainers" | "losers";
-
-export type Period = "rt" | "1d" | "7d" | "1m" | "3m" | "6m" | "1y";
+export type Category = "notional" | "volume" | "pct_up" | "pct_down";
+export type Period = "RT" | "1D" | "7D" | "1M" | "3M" | "6M" | "1Y";
 
 export const PERIODS_BY_CATEGORY: Record<Category, Period[]> = {
-  notional: ["rt", "1d", "7d", "1m", "3m", "6m", "1y"],
-  volume: ["rt", "1d", "7d", "1m", "3m", "6m", "1y"],
-  gainers: ["1d", "7d", "1m", "3m", "6m", "1y"], // 실시간 제외
-  losers: ["1d", "7d", "1m", "3m", "6m", "1y"], // 실시간 제외
+  notional: ["RT", "1D", "7D", "1M", "3M", "6M"],
+  volume: ["RT", "1D", "7D", "1M", "3M", "6M"],
+  pct_up: ["1D", "7D", "1M", "3M", "6M"], // 실시간 제외
+  pct_down: ["1D", "7D", "1M", "3M", "6M"], // 실시간 제외
 };
 
-export type Stock = {
+export type RankingItem = {
+  metric: Category;
+  timeframe: Period;
   rank: number;
-  productCode: string;
-  name: string;
-  logoImageUrl: string;
-  price: {
-    base: number;
-    close: number;
-    Volume?: number;
-    Amount?: number;
-  };
-  extraInfo: {
-    Buy: number;
-    Sell: number;
-  };
+  symbol: string;
+  symbol_kor?: string;
+  value: number; // 거래대금/거래량 합 또는 등락률(%)
+  prev_rank: number;
+  rank_change: number;
+  current_price: number;
+  anchor_price: number;
+  rt_price?: number;
+  rt_ts?: string;
+  updated_at: string;
 };

--- a/supabase/functions/ranking-updator/index.ts
+++ b/supabase/functions/ranking-updator/index.ts
@@ -19,6 +19,21 @@ Deno.serve(async () => {
       });
       if (error)
         console.error(`[rankings-updater] ${metric}/${timeframe}`, error);
+
+      try {
+        await supabaseClient.channel(`rankings:${metric}:${timeframe}`).send({
+          type: "broadcast",
+          event: "updated",
+          payload: {
+            event: "updated",
+            metric,
+            timeframe,
+            ts: new Date().toISOString(),
+          },
+        });
+      } catch (broadcastError) {
+        console.error(`[broadcast] ${metric}/${timeframe}`, broadcastError);
+      }
     }
   }
 

--- a/supabase/functions/stock-calendar-updator/index.ts
+++ b/supabase/functions/stock-calendar-updator/index.ts
@@ -1,0 +1,89 @@
+import { supabaseClient } from "@shared/supabaseClient.ts";
+import { DateTime } from "npm:luxon@3.4.4";
+
+const CALENDAL_URL = "https://paper-api.alpaca.markets/v2/calendar";
+const ET = "America/New_York";
+
+const iso = (d: Date) => d.toISOString();
+
+const toHHMM = (s: string) =>
+  s.includes(":") ? s : `${s.slice(0, 2)}:${s.slice(2)}`;
+
+const toUtcIso = (dateEt: string, hhmmEt: string) =>
+  DateTime.fromISO(`${dateEt}T${toHHMM(hhmmEt)}`, { zone: ET })
+    .toUTC()
+    .toISO({ suppressMilliseconds: true });
+
+type reqPayload = {
+  start: string | Date;
+  end: string | Date;
+};
+
+async function fetchStockCalendar(params: reqPayload) {
+  const { start, end } = params;
+  const url = new URL(CALENDAL_URL);
+  url.searchParams.set("start", iso(new Date(start)));
+  url.searchParams.set("end", iso(new Date(end)));
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json",
+      "APCA-API-KEY-ID": Deno.env.get("ALPACA_KEY_ID")!,
+      "APCA-API-SECRET-KEY": Deno.env.get("ALPACA_SECRET_KEY")!,
+    },
+  });
+
+  if (!res.ok) throw new Error(await res.text());
+  const result = await res.json();
+
+  const calendars = [];
+  for (const item of result) {
+    calendars.push({
+      trade_date: item.date,
+      open_time: toUtcIso(item.date, item.open),
+      close_time: toUtcIso(item.date, item.close),
+      session_open: toUtcIso(item.date, item.session_open),
+      session_close: toUtcIso(item.date, item.session_close),
+      settlement_date: item.settlement_date,
+    });
+  }
+
+  return calendars;
+}
+
+Deno.serve(async (req) => {
+  try {
+    if (req.method !== "POST")
+      return new Response("Method Not Allowed", { status: 405 });
+
+    const params: reqPayload = await req.json();
+    const result = await fetchStockCalendar(params);
+
+    const { error } = await supabaseClient
+      .from("market_calendar")
+      .upsert(result, { onConflict: "trade_date" });
+
+    if (error) throw error;
+    return new Response(JSON.stringify({ ok: true, data }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    return new Response(
+      JSON.stringify({ ok: false, error: String(e?.message ?? e) }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+});
+
+/*
+배포 및 테스트
+supabase functions deploy stock-calendar-updator --import-map functions/deno.json
+
+ curl -L -X POST 'https://fvvutdyuxljohzbvmgzu.supabase.co/functions/v1/stock-calendar-updator' \
+  -H 'Authorization: Bearer your-token' \
+  -H 'Content-Type: application/json' \
+  --data '{"start":"2025-09-10", "end": "2026-12-31"}'
+ */


### PR DESCRIPTION
## ✨ 개요

<!-- 이번 PR에서 무엇을 했는지 간단히 설명 (ex: 회원가입 이메일 중복 검사 기능 추가) -->
실시간 차트 랭킹 데이터 연동 및 현재가, 등락률 실시간 업데이트 기능 추가

## 💡 변경 내용

<!-- 주요 변경사항을 요약해서 bullet point로 작성해주세요. -->

(supabase)
- 마켓 캘린더 데이터 저장 API 추가
- 랭킹 업데이트 이벤트 발생 로직 추가 (supabase broadcast)

(react)
- react-use-websocket 라이브러리 설치
- utils.ts : date, commaFormat 함수 및 getPeriodText 함수 추가
- 랭킹 업데이트시에 실시간 조회 api 및 마켓 정보 api 추가
- 전체 랭킹 타입 네이밍 수정
- 테이블 컴포넌트 css 수정 및 index.css 애니메이션 css 추가
- 마켓 정보 hook 추가
- 실시간 현재가 조회하는 웹소켓 hook 추가
- 실시간 현재가 업데이트 기능
- 마켓 정보, 업데이트 날짜 데이터 업데이트


## 📸 스크린샷 (선택 사항)

<!-- UI/UX 변경 사항이 있을 경우, 관련 스크린샷이나 GIF를 Before / After 캡처를 첨부해주세요. -->
<img width="1506" height="816" alt="image" src="https://github.com/user-attachments/assets/6d5553ef-5c57-4832-a65d-4185aab94edf" />


## 🧩 관련 이슈

<!-- PR과 관련된 이슈 번호를 링크하세요. -->

- Issue: #44

## 🧐 리뷰어에게

<!-- 리뷰 시 중점적으로 확인할 부분이나 주의할 점을 작성해주세요 -->
랭킹을 실시간으로 업데이트 하는 로직이 의도대로 잘 동작되고 있는지 궁금합니다.
(랭킹 크론 → Supabase broadcast → 클라이언트 구독)

웹소켓 수신이 과하게 동작하고 있진 않은지 확인해주세요.

## ✅ Checklist

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  Self-Review를 완료했습니다.
- [ ]  문서가 필요한 경우, 관련 문서를 업데이트했습니다.
